### PR TITLE
CHUI-9: Add route to get country settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Routes `/country-settings/` and `/country-settings/:country` to retrieve country configurations.
 
 ## [0.1.0] - 2020-06-30
 ### Added

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,8 +1,14 @@
-import { Service } from '@vtex/api'
+import { Service, method } from '@vtex/api'
 
 import resolvers from './resolvers'
+import { countrySettings } from './middlewares/countrySettings'
+import { allCountrySettings } from './middlewares/allCountrySettings'
 
 export default new Service({
+  routes: {
+    countrySettings: method({ GET: [countrySettings] }),
+    allCountrySettings: method({ GET: [allCountrySettings] }),
+  },
   graphql: {
     resolvers,
   },

--- a/node/middlewares/allCountrySettings.ts
+++ b/node/middlewares/allCountrySettings.ts
@@ -1,0 +1,9 @@
+import { ServiceContext } from '@vtex/api'
+
+import { getSettingsByCountry } from '../utils/getSettingsByCountry'
+
+export function allCountrySettings(ctx: ServiceContext) {
+  const allSettings = getSettingsByCountry(ctx.vtex.settings)
+
+  ctx.body = Object.values(allSettings)
+}

--- a/node/middlewares/countrySettings.ts
+++ b/node/middlewares/countrySettings.ts
@@ -1,0 +1,11 @@
+import { ServiceContext } from '@vtex/api'
+
+import { getSettingsByCountry } from '../utils/getSettingsByCountry'
+
+export function countrySettings(ctx: ServiceContext) {
+  const country = ctx.vtex.route.params.country as string
+
+  const allSettings = getSettingsByCountry(ctx.vtex.settings)
+
+  ctx.body = allSettings[country]
+}

--- a/node/package.json
+++ b/node/package.json
@@ -4,7 +4,7 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "@types/graphql-type-json": "^0.3.2",
-    "@vtex/api": "6.31.1"
+    "@vtex/api": "6.33.0"
   },
   "dependencies": {
     "graphql": "^14.6.0",

--- a/node/package.json
+++ b/node/package.json
@@ -4,7 +4,8 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "@types/graphql-type-json": "^0.3.2",
-    "@vtex/api": "6.33.0"
+    "@vtex/api": "6.33.0",
+    "@vtex/tsconfig": "^0.5.0"
   },
   "dependencies": {
     "graphql": "^14.6.0",

--- a/node/resolvers/country.ts
+++ b/node/resolvers/country.ts
@@ -1,26 +1,6 @@
 import { ServiceContext } from '@vtex/api'
 
-const getSettingsByCountry = (settings: Configuration[]) => {
-  const settingsByCountry = settings.reduce<{
-    [country: string]: CountryDataConfiguration
-  }>((groupedConfigs, configuration) => {
-    const { declarer } = configuration
-
-    const [declarerAppName] = declarer.split('@')
-
-    if (!configuration[declarerAppName]) {
-      return groupedConfigs
-    }
-
-    const countryConfig = configuration[declarerAppName]
-
-    groupedConfigs[countryConfig.countryISO] = countryConfig
-
-    return groupedConfigs
-  }, {})
-
-  return settingsByCountry
-}
+import { getSettingsByCountry } from '../utils/getSettingsByCountry'
 
 export const root = {
   AdditionalFieldData: {

--- a/node/service.json
+++ b/node/service.json
@@ -1,0 +1,28 @@
+{
+  "routes": {
+    "countrySettings": {
+      "path": "/country-settings/:country",
+      "settingsType": "workspace",
+      "access": "public",
+      "policies": [
+        {
+          "effect": "allow",
+          "actions": ["get"],
+          "principals": ["vrn:apps:*:{{account}}:{{workspace}}:app/vtex.*"]
+        }
+      ]
+    },
+    "allCountrySettings": {
+      "path": "/country-settings/",
+      "settingsType": "workspace",
+      "access": "public",
+      "policies": [
+        {
+          "effect": "allow",
+          "actions": ["get"],
+          "principals": ["vrn:apps:*:{{account}}:{{workspace}}:app/vtex.*"]
+        }
+      ]
+    }
+  }
+}

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -1,23 +1,11 @@
 {
+  "extends": "@vtex/tsconfig",
   "compilerOptions": {
     "types": ["node"],
     "target": "es2019",
-    "module": "commonjs",
-    "sourceMap": false,
     "allowJs": true,
-    "noImplicitThis": true,
-    "moduleResolution": "node",
-    "skipLibCheck": true,
-    "alwaysStrict": true,
-    "esModuleInterop": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "strictFunctionTypes": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true
-  },
-  "typeAcquisition": {
-    "enable": false
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
   },
   "include": ["./typings/*.d.ts", "./**/*.ts"],
   "exclude": ["node_modules"]

--- a/node/utils/getSettingsByCountry.ts
+++ b/node/utils/getSettingsByCountry.ts
@@ -1,0 +1,21 @@
+export const getSettingsByCountry = (settings: Configuration[]) => {
+  const settingsByCountry = settings.reduce<{
+    [country: string]: CountryDataConfiguration
+  }>((groupedConfigs, configuration) => {
+    const { declarer } = configuration
+
+    const [declarerAppName] = declarer.split('@')
+
+    if (!configuration[declarerAppName]) {
+      return groupedConfigs
+    }
+
+    const countryConfig = configuration[declarerAppName]
+
+    groupedConfigs[countryConfig.countryISO] = countryConfig
+
+    return groupedConfigs
+  }, {})
+
+  return settingsByCountry
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -123,10 +123,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.31.1":
-  version "6.31.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.31.1.tgz#dcb7bddb0b77d6a1ad936da0a6bbc42d577b7883"
-  integrity sha512-KogyA3ZL4behY/8HG7SormxbcOnETJAre6sWkUvSbl1SYLoeL/znvMigzp5812lGDxqjwcIxW6AdFP2Qla+8zw==
+"@vtex/api@6.33.0":
+  version "6.33.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.33.0.tgz#8aca963a8b4a33d06321f8de3f5b224d4eec76ce"
+  integrity sha512-eguTB4WgSJJ+Hi90Uvy8jiu/OtyB6PV4IpixDH6197knFmmaif6L7lf34n8zkJ2sbJLFsYHDbk3WgCU2qNVexA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1442,7 +1442,7 @@ signal-exit@^3.0.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -176,6 +176,11 @@
   dependencies:
     is-stream "^2.0.0"
 
+"@vtex/tsconfig@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@vtex/tsconfig/-/tsconfig-0.5.0.tgz#1314b4cb0c9503ebcae3afd1ec36106dc457cd5c"
+  integrity sha512-WDdawn5pzTj22tVod/MhWU+qCnYu4cCKtmEErwPC9TebJ5OGJTxJnFKskAMJgKjIZmAORDZBq3fsvzCcxC1mgg==
+
 "@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
@@ -1442,7 +1447,7 @@ signal-exit@^3.0.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Adds the equivalent REST routes for the GraphQL queries. This is useful to integrate this app with other backend/node apps.

#### How should this be manually tested?

[Workspace](https://steps--checkoutio.myvtex.com). Not much to test yet, I'll open a PR later in `vtex.checkout-graphql` that will use these endpoints and I'll add a better test plan there.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->