### PR TITLE
CHK-470: Add `brief` as a new display type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Field `brief` as a new display type.
 
 ## [0.3.0] - 2020-10-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# Country Data Settings

--- a/configuration/schema.json
+++ b/configuration/schema.json
@@ -107,6 +107,9 @@
         "minimal": {
           "$ref": "#/definitions/addressDisplay"
         },
+        "brief": {
+          "$ref": "#/definitions/addressDisplay"
+        },
         "compact": {
           "$ref": "#/definitions/addressDisplay"
         },

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,31 @@
+# Country Data Settings
+
+⚠️ **This is an ongoing, unsupported, unfinished and undocumented project. We do not guarantee any results after installation.** ⚠️
+
+<!-- DOCS-IGNORE:start -->
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
+[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+<!-- DOCS-IGNORE:end -->
+
+Configuration definitions for countries at https://github.com/vtex-apps/countries-data.
+
+<!-- DOCS-IGNORE:start -->
+
+## Contributors ✨
+
+Thanks goes to these wonderful people:
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!
+
+<!-- DOCS-IGNORE:end -->

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -15,6 +15,7 @@ type DisplayDefinition {
 
 type DisplayData {
   minimal: [[DisplayDefinition!]!]!
+  brief: [[DisplayDefinition!]!]!
   compact: [[DisplayDefinition!]!]!
   extended: [[DisplayDefinition!]!]!
 }

--- a/node/package.json
+++ b/node/package.json
@@ -4,7 +4,7 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "@types/graphql-type-json": "^0.3.2",
-    "@vtex/api": "6.36.3",
+    "@vtex/api": "6.37.1",
     "@vtex/tsconfig": "^0.5.0"
   },
   "dependencies": {

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -25,6 +25,7 @@ declare global {
 
   interface DisplayData {
     minimal: DisplayDefinition[][]
+    brief: DisplayDefinition[][]
     compact: DisplayDefinition[][]
     expanded: DisplayDefinition[][]
   }

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -123,10 +123,10 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
-"@vtex/api@6.36.3":
-  version "6.36.3"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.36.3.tgz#d827944829fb289d3a826cac12874f8e33ce62f5"
-  integrity sha512-i7zZ0Mj5pGEr6wd8VCK/hhiKTmmiuTn44v9MlWn36MRvtfBfOsKlhMFUEv3HBT1MH+fQTNM9vY08uSy7BsG44w==
+"@vtex/api@6.37.1":
+  version "6.37.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.37.1.tgz#d6ded4f4a98e10596729af7097cff18be43a0e54"
+  integrity sha512-24BaVHCIbkC84UWAlGPuTnUYIFngOpeRa4u/6KCJDnir5GXjoCWAkj4E7OoQ2uvBy/uvs9X2+DIkqtiz1x5bvw==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What problem is this solving?

In order to improve the UX when displaying place data, countries can now config a `brief` display, which is between `minimal` and `compact` display, in terms of content size.

#### How should this be manually tested?

[GraphQL query](https://geolocation--checkoutio.myvtex.com/_v/private/vtex.country-data-settings@0.3.0/graphiql/v1?query=%7B%0A%20%20braData%3A%20countryData(country%3A%20%22BRA%22)%20%7B%0A%20%20%20%20display%20%7B%0A%20%20%20%20%20%20brief%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20delimiter%0A%20%20%20%20%20%20%20%20delimiterAfter%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20bolData%3A%20countryData(country%3A%20%22BOL%22)%20%7B%0A%20%20%20%20display%20%7B%0A%20%20%20%20%20%20brief%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20delimiter%0A%20%20%20%20%20%20%20%20delimiterAfter%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20argData%3A%20countryData(country%3A%20%22ARG%22)%20%7B%0A%20%20%20%20display%20%7B%0A%20%20%20%20%20%20brief%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20delimiter%0A%20%20%20%20%20%20%20%20delimiterAfter%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20usaData%3A%20countryData(country%3A%20%22USA%22)%20%7B%0A%20%20%20%20display%20%7B%0A%20%20%20%20%20%20brief%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20delimiter%0A%20%20%20%20%20%20%20%20delimiterAfter%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)